### PR TITLE
Add \< and \> for the BRE and ERE

### DIFF
--- a/regex.html
+++ b/regex.html
@@ -116,7 +116,7 @@ td.na {
   </tbody>
   <tbody id="syntax-assert" class="subgroup">
     <tr><th colspan="6">Zero-width assertions</th></tr>
-    <tr><td>Word boundary</td><td><code>\b</code></td><td><code>\b</code></td><td><code>\b</code></td><td><code>\b</code></td><td><code>\&lt;</code> / <code>\&gt;</code></td></tr>
+    <tr><td>Word boundary</td><td><code>\b</code></td><td><code>\b</code></td><td><code>\b</code> / <code>\&lt;</code> / <code>\&gt;</code></td><td><code>\b</code> / <code>\&lt;</code> / <code>\&gt;</code></td><td><code>\&lt;</code> / <code>\&gt;</code></td></tr>
     <tr><td>Anywhere but word boundary</td><td><code>\B</code></td><td><code>\B</code></td><td><code>\B</code></td><td><code>\B</code></td><td class="na"></td></tr>
     <tr><td>Beginning of line/string</td><td><code>^</code> / <code>\A</code></td><td><code>^</code> / <code>\A</code></td><td><code>^</code></td><td><code>^</code></td><td><code>^</code> (beginning of pattern ) <code>\_^</code></td></tr>
     <tr><td>End of line/string</td><td><code>$</code> / <code>\Z</code></td><td><code>$</code> / <code>\Z</code></td><td><code>$</code></td><td><code>$</code></td><td><code>$</code> (end of pattern) <code>\_$</code></td></tr>

--- a/regex.html
+++ b/regex.html
@@ -116,7 +116,7 @@ td.na {
   </tbody>
   <tbody id="syntax-assert" class="subgroup">
     <tr><th colspan="6">Zero-width assertions</th></tr>
-    <tr><td>Word boundary</td><td><code>\b</code></td><td><code>\b</code></td><td><code>\b</code> / <code>\&lt;</code> / <code>\&gt;</code></td><td><code>\b</code> / <code>\&lt;</code> / <code>\&gt;</code></td><td><code>\&lt;</code> / <code>\&gt;</code></td></tr>
+    <tr><td>Word boundary</td><td><code>\b</code></td><td><code>\b</code></td><td><code>\b</code> / <code>\&lt;</code> (start) / <code>\&gt;</code> (end)</td><td><code>\b</code> / <code>\&lt;</code> (start) / <code>\&gt;</code> (end)</td><td><code>\&lt;</code> (start) / <code>\&gt;</code> (end)</td></tr>
     <tr><td>Anywhere but word boundary</td><td><code>\B</code></td><td><code>\B</code></td><td><code>\B</code></td><td><code>\B</code></td><td class="na"></td></tr>
     <tr><td>Beginning of line/string</td><td><code>^</code> / <code>\A</code></td><td><code>^</code> / <code>\A</code></td><td><code>^</code></td><td><code>^</code></td><td><code>^</code> (beginning of pattern ) <code>\_^</code></td></tr>
     <tr><td>End of line/string</td><td><code>$</code> / <code>\Z</code></td><td><code>$</code> / <code>\Z</code></td><td><code>$</code></td><td><code>$</code></td><td><code>$</code> (end of pattern) <code>\_$</code></td></tr>


### PR DESCRIPTION
```bash
$ alias g
alias g='grep'
$ echo 'apple is not orange' | g '\<is' -o
is
$ echo 'apple is not orange' | g '\>is' -o
$
```

```bash
$ echo 'apple is not orange' | g -E '\<is' -o
is
$ echo 'apple is not orange' | g -E '\>is' -o
$
```

```bash
$ echo 'apple is not orange' | sed 's/\<is/IS/'
apple IS not orange
$ echo 'apple is not orange' | sed 's/\>is/IS/'
apple is not orange
```

Thanks for the awesome cheatsheet, and I believe you will like this pull request.